### PR TITLE
fix(ChibiManga): switch to alternative ajax endpoint

### DIFF
--- a/src/ChibiManga/ChibiManga.ts
+++ b/src/ChibiManga/ChibiManga.ts
@@ -29,7 +29,7 @@ export class ChibiManga extends Madara {
 
     baseUrl: string = DOMAIN
 
-    override alternativeChapterAjaxEndpoint = false
+    override alternativeChapterAjaxEndpoint = true
 
     override hasAdvancedSearchPage = true
 }

--- a/src/ChibiManga/ChibiManga.ts
+++ b/src/ChibiManga/ChibiManga.ts
@@ -13,7 +13,7 @@ import {
 const DOMAIN = 'https://www.cmreader.info'
 
 export const ChibiMangaInfo: SourceInfo = {
-    version: getExportVersion('0.0.0'),
+    version: getExportVersion('0.0.1'),
     name: 'ChibiManga',
     description: `Extension that pulls manga from ${DOMAIN}`,
     author: 'Netsky',


### PR DESCRIPTION
ChibiManga chapter list has been broken since they came back up after the Madrara vulnerability stuff. Looks like it needs the alternative endpoint now.