### PR TITLE
Add additional conditional check for getting image source urls

### DIFF
--- a/src/Madara.ts
+++ b/src/Madara.ts
@@ -23,7 +23,7 @@ import {
 import { Parser } from './MadaraParser'
 import { URLBuilder } from './MadaraHelper'
 
-const BASE_VERSION = '3.1.1'
+const BASE_VERSION = '3.1.2'
 export const getExportVersion = (EXTENSION_VERSION: string): string => {
     return BASE_VERSION.split('.').map((x, index) => Number(x) + Number(EXTENSION_VERSION.split('.')[index])).join('.')
 }

--- a/src/MadaraParser.ts
+++ b/src/MadaraParser.ts
@@ -118,7 +118,7 @@ export class Parser {
     async parseChapterDetails($: CheerioSelector, mangaId: string, chapterId: string, selector: string, source: any): Promise<ChapterDetails> {
         const pages: string[] = []
 
-        for (const obj of $(selector).toArray()) {
+        for (const obj of $(selector).get()) {
             const page = await this.getImageSrc($(obj), source)
             if (!page) {
                 throw new Error(`Could not parse page for postId:${mangaId} chapterId:${chapterId}`)
@@ -234,19 +234,19 @@ export class Parser {
 
     async getImageSrc(imageObj: Cheerio | undefined, source: any): Promise<string> {
         let image: string | undefined
-        if ((typeof imageObj?.attr('data-src')) != 'undefined') {
+        if ((typeof imageObj?.attr('data-src')) != 'undefined' && imageObj?.attr('data-src') != '') {
             image = imageObj?.attr('data-src')
         }
-        else if ((typeof imageObj?.attr('data-lazy-src')) != 'undefined') {
+        else if ((typeof imageObj?.attr('data-lazy-src')) != 'undefined' && imageObj?.attr('data-lazy-src') != '') {
             image = imageObj?.attr('data-lazy-src')
         }
-        else if ((typeof imageObj?.attr('srcset')) != 'undefined') {
+        else if ((typeof imageObj?.attr('srcset')) != 'undefined' && imageObj?.attr('srcset') != '') {
             image = imageObj?.attr('srcset')?.split(' ')[0] ?? ''
         }
-        else if ((typeof imageObj?.attr('src')) != 'undefined') {
+        else if ((typeof imageObj?.attr('src')) != 'undefined' && imageObj?.attr('src') != '') {
             image = imageObj?.attr('src')
         }
-        else if ((typeof imageObj?.attr('data-cfsrc')) != 'undefined') {
+        else if ((typeof imageObj?.attr('data-cfsrc')) != 'undefined' && imageObj?.attr('data-cfsrc') != '') {
             image = imageObj?.attr('data-cfsrc')
         } else {
             image = ''


### PR DESCRIPTION
Adds empty string checking beside undefined object checking for image element attributes.
Coincidentally resolves #48 
Rather than opting to alter the actual conditional flow, I instead added a second conditional statement to be passed, as it creates new behavior.