### PR TITLE
Update buddycomplex functions and fix missing chapters in mangabuddy

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@paperback/toolchain": "^0.8.0-alpha.47",
     "@paperback/types": "^0.8.0-alpha.47",
     "cheerio": "^1.0.0-rc.12",
-    "entities": "^4.4.0",
+    "html-entities": "^2.5.2",
     "nodemon": "^2.0.22",
     "ts-node": "^10.2.1"
   }

--- a/src/BuddyComplexParser.ts
+++ b/src/BuddyComplexParser.ts
@@ -78,7 +78,7 @@ export class BuddyComplexParser {
         for (const chapter of $('li', 'ul.chapter-list').toArray()) {
             const title = $('strong.chapter-title', chapter).text().trim()
             const id = this.idCleaner($('a', chapter).attr('href') ?? '')
-            const date = new Date($('time.chapter-update', chapter)?.text() ?? '')
+            const date = this.parseDate($('time.chapter-update', chapter)?.text() ?? '')
             if (!id) continue
 
             // Check chapter/ch-* regex first
@@ -108,6 +108,7 @@ export class BuddyComplexParser {
         }
 
         return chapters.map(chapter => {
+            // Inverts the sortingIndex to have the chapters in the correct order
             chapter.sortingIndex += chapters.length
             return App.createChapter(chapter)
         })
@@ -344,7 +345,15 @@ export class BuddyComplexParser {
     protected parseDate = (date: string): Date => {
         date = date.toUpperCase()
         let time: Date
-        const number = Number((/\d*/.exec(date) ?? [])[0])
+        const extractedNumber = (/\d*/.exec(date) ?? [])[0]
+        let number = 0
+        if (extractedNumber == '') {
+            if (date.startsWith('AN') || date.startsWith('A ')) {
+                number = 1
+            }
+        } else {
+            number = isNaN(Number(extractedNumber)) ? 0 : Number(extractedNumber)
+        }
         if (date.includes('LESS THAN AN HOUR') || date.includes('JUST NOW')) {
             time = new Date(Date.now())
         } else if (date.includes('YEAR') || date.includes('YEARS')) {

--- a/src/BuddyComplexParser.ts
+++ b/src/BuddyComplexParser.ts
@@ -8,7 +8,7 @@ import {
     HomeSection
 } from '@paperback/types'
 
-import entities = require('entities')
+import { decode as decodeHTML } from 'html-entities'
 
 export interface UpdatedManga {
     ids: string[];
@@ -338,7 +338,7 @@ export class BuddyComplexParser {
     }
 
     protected decodeHTMLEntity(str: string): string {
-        return entities.decodeHTML(str)
+        return decodeHTML(str)
     }
 
     protected parseDate = (date: string): Date => {

--- a/src/MangaBuddy/MangaBuddy.ts
+++ b/src/MangaBuddy/MangaBuddy.ts
@@ -17,7 +17,7 @@ import { MangaBuddyParser } from './MangaBuddyParser'
 const DOMAIN = 'https://mangabuddy.com'
 
 export const MangaBuddyInfo: SourceInfo = {
-    version: getExportVersion('0.0.1'),
+    version: getExportVersion('0.0.2'),
     name: 'MangaBuddy',
     description: `Extension that pulls manga from ${DOMAIN}`,
     author: 'Netsky',

--- a/src/MangaBuddy/MangaBuddyParser.ts
+++ b/src/MangaBuddy/MangaBuddyParser.ts
@@ -1,0 +1,28 @@
+import { Chapter } from '@paperback/types'
+import { BuddyComplexParser } from '../BuddyComplexParser'
+
+export class MangaBuddyParser extends BuddyComplexParser {
+    fullParseChapterList($: CheerioSelector, mangaId: string, mangaPage$: CheerioSelector): Chapter[] {
+        const chapters: Chapter[] = super.parseChapterList($, mangaId)
+        if (chapters.length === 0) {
+            return chapters
+        }
+
+        const lastChapters: Chapter[] = super.parseChapterList(mangaPage$, mangaId)
+        if (lastChapters.length === 0) {
+            return chapters
+        }
+
+        const finalChapters = lastChapters.concat(chapters.filter(chapter => !lastChapters.some(chap => chap.id == chapter.id)))
+        let sortingIndex = 0
+        finalChapters.sort((a, b) => {
+            return a.chapNum < b.chapNum ? -1 : 1
+        })
+        finalChapters.forEach(chapter => {
+            chapter.sortingIndex = sortingIndex
+            sortingIndex++
+        })
+
+        return finalChapters
+    }
+}


### PR DESCRIPTION
This pull request includes:
- Utilizing the parseData function (it was unused before)
- Fixing the parseData function (it didn't account for 'a' or 'an' substituting as 1)
- Getting chapters from both manga page and chapter list for mangabuddy
- Switching from entities to html-entities due to license mismatch and ESM compliance