### PR TITLE
Implement the CloudflareBypass method for Captcha

### DIFF
--- a/src/MangaBat/MangaBat.ts
+++ b/src/MangaBat/MangaBat.ts
@@ -13,7 +13,7 @@ import {
 const SITE_DOMAIN = 'https://h.mangabat.com'
 
 export const MangaBatInfo: SourceInfo = {
-    version: getExportVersion('0.0.3'),
+    version: getExportVersion('0.0.5'),
     name: 'MangaBat',
     icon: 'icon.png',
     author: 'Batmeow',
@@ -40,4 +40,6 @@ export class MangaBat extends MangaBox {
 
     // Selector for subtitle in manga list.
     mangaSubtitleSelector = 'div.item-right > a.item-chapter'
+
+    bypassPage = ''
 }

--- a/src/Mangakakalot/Mangakakalot.ts
+++ b/src/Mangakakalot/Mangakakalot.ts
@@ -24,7 +24,7 @@ import { URLBuilder } from '../MangaBoxHelpers'
 const SITE_DOMAIN = 'https://mangakakalot.com'
 
 export const MangakakalotInfo: SourceInfo = {
-    version: getExportVersion('0.0.3'),
+    version: getExportVersion('0.1.0'),
     name: 'Mangakakalot',
     icon: 'icon.png',
     author: 'Batmeow',
@@ -33,7 +33,7 @@ export const MangakakalotInfo: SourceInfo = {
     contentRating: ContentRating.MATURE,
     websiteBaseURL: SITE_DOMAIN,
     sourceTags: [],
-    intents: SourceIntents.SETTINGS_UI | SourceIntents.HOMEPAGE_SECTIONS | SourceIntents.MANGA_CHAPTERS
+    intents: SourceIntents.SETTINGS_UI | SourceIntents.HOMEPAGE_SECTIONS | SourceIntents.MANGA_CHAPTERS | SourceIntents.CLOUDFLARE_BYPASS_REQUIRED
 }
 
 export class Mangakakalot extends MangaBox {
@@ -51,6 +51,9 @@ export class Mangakakalot extends MangaBox {
 
     // Selector for subtitle in manga list.
     mangaSubtitleSelector = 'a.list-story-item-wrap-chapter'
+
+    // Page that requires captcha to access.
+    bypassPage = 'https://chapmanganato.to/'
 
     override async supportsTagExclusion(): Promise<boolean> {
         return false

--- a/src/Manganato/Manganato.ts
+++ b/src/Manganato/Manganato.ts
@@ -13,7 +13,7 @@ import {
 const SITE_DOMAIN = 'https://manganato.com'
 
 export const ManganatoInfo: SourceInfo = {
-    version: getExportVersion('0.0.3'),
+    version: getExportVersion('0.1.0'),
     name: 'Manganato',
     icon: 'icon.png',
     author: 'Batmeow',
@@ -22,7 +22,7 @@ export const ManganatoInfo: SourceInfo = {
     contentRating: ContentRating.MATURE,
     websiteBaseURL: SITE_DOMAIN,
     sourceTags: [],
-    intents: SourceIntents.SETTINGS_UI | SourceIntents.HOMEPAGE_SECTIONS | SourceIntents.MANGA_CHAPTERS
+    intents: SourceIntents.SETTINGS_UI | SourceIntents.HOMEPAGE_SECTIONS | SourceIntents.MANGA_CHAPTERS | SourceIntents.CLOUDFLARE_BYPASS_REQUIRED
 }
 
 export class Manganato extends MangaBox {
@@ -40,4 +40,7 @@ export class Manganato extends MangaBox {
 
     // Selector for subtitle in manga list.
     mangaSubtitleSelector = 'a.genres-item-chap.text-nowrap'
+
+    // Page that requires captcha to access.
+    bypassPage = 'https://chapmanganato.to/'
 }


### PR DESCRIPTION
Manganato and Mangakakalot implemented a robot detection/captcha on "chapmanganato.to". The robot detection/captcha doesn't appear to be enabled on MangaBat so that one was left as is for now.

- Implements getCloudflareBypassRequestAsync.
- Bypass for Manganato and Mangakakalot
- Minor version bump on Manganato and Mangakakalot

I did some tests on my end and it appears to be working with the Bypass.