### PR TITLE
Mangabox: Patch for chapter and description selectors

### DIFF
--- a/src/MangaBox.ts
+++ b/src/MangaBox.ts
@@ -30,7 +30,7 @@ import {
     resetSettings
 } from './MangaBoxSettings'
 
-const BASE_VERSION = '1.0.0'
+const BASE_VERSION = '1.0.1'
 export const getExportVersion = (EXTENSION_VERSION: string): string => {
     return BASE_VERSION.split('.').map((x, index) => Number(x) + Number(EXTENSION_VERSION.split('.')[index])).join('.')
 }

--- a/src/MangaBox.ts
+++ b/src/MangaBox.ts
@@ -96,7 +96,7 @@ export abstract class MangaBox implements SearchResultsProviding, MangaProviding
         + 'ul.manga-info-text li:contains(Author) a'
 
     // Selector for manga description.
-    mangaDescSelector = 'div#panel-story-info-description, div#noidungm, div.manga-info-top + div#contentBox'
+    mangaDescSelector = 'div.chapter + div#contentBox, div#panel-story-info-description, div#noidungm, div.manga-info-top + div#contentBox'
 
     // Selector for manga tags.
     mangaGenresSelector = 'div.story-info-right td:contains(Genre) + td a,'

--- a/src/MangaBoxParser.ts
+++ b/src/MangaBoxParser.ts
@@ -151,15 +151,18 @@ export class MangaBoxParser {
             .then(server => parseInt((server[0]?.replace('server', '')) ?? '1') - 1)
 
         const cdnsMatch = ($('head').toString().match(/var cdns.*]/g) ?? [])[0]?.replace('var cdns = ', '')
-        const cdns = JSON.parse(cdnsMatch)
 
         for (const img of $(source.chapterImagesSelector).toArray()) {
             let image = $(img).attr('src') ?? ''
             if (!image) image = $(img).attr('data-src') ?? ''
             if (!image) throw new Error(`Unable to parse image(s) for Chapter ID: ${chapterId}`)
-            if (Array.isArray(cdns) && typeof cdns[imageServer] !== 'undefined') {
-                for (const url of cdns) image = image.replace(url, cdns[imageServer])
+            if (cdnsMatch) {
+                const cdns = JSON.parse(cdnsMatch)
+                if (Array.isArray(cdns) && typeof cdns[imageServer] !== 'undefined') {
+                    for (const url of cdns) image = image.replace(url, cdns[imageServer])
+                }
             }
+
             pages.push(image)
         }
 


### PR DESCRIPTION
This PR fixes chapter image selector throwing undefined due to missing CDN selector being parsed as well as fixes to the Manga Descriptions one some sources now moved under the chapter list.

Base Source:

- Add additional manga description selector.
- Add a check for `cdnsMatch` to avoid parsing undefined.
- Patch version increase globally.