### PR TITLE
MangaBox: Update Selectors

### DIFF
--- a/src/MangaBat/MangaBat.ts
+++ b/src/MangaBat/MangaBat.ts
@@ -12,7 +12,7 @@ import {
 const SITE_DOMAIN = 'https://www.mangabats.com'
 
 export const MangaBatInfo: SourceInfo = {
-    version: getExportVersion('4.0.1'),
+    version: getExportVersion('4.0.2'),
     name: 'MangaBat',
     icon: 'icon.png',
     author: 'Batmeow',
@@ -38,7 +38,7 @@ export class MangaBat extends MangaBox {
     mangaListHomeSectionsPath = 'all'
 
     // Selector for manga in manga list.
-    mangaListSelector = 'div.truyen-list div.list-truyen-item-wrap'
+    mangaListSelector = 'div.comic-list div.list-comic-item-wrap'
 
     // Selector for subtitle in manga list.
     mangaSubtitleSelector = 'a.list-story-item-wrap-chapter'

--- a/src/MangaBox.ts
+++ b/src/MangaBox.ts
@@ -96,7 +96,7 @@ export abstract class MangaBox implements SearchResultsProviding, MangaProviding
         + 'ul.manga-info-text li:contains(Author) a'
 
     // Selector for manga description.
-    mangaDescSelector = 'div.chapter + div#contentBox, div#panel-story-info-description, div#noidungm, div.manga-info-top + div#contentBox'
+    mangaDescSelector = 'div.leftCol div#contentBox, div.chapter + div#contentBox, div#panel-story-info-description, div.manga-info-top + div#contentBox'
 
     // Selector for manga tags.
     mangaGenresSelector = 'div.story-info-right td:contains(Genre) + td a,'

--- a/src/MangakakalotGG/MangakakalotGG.ts
+++ b/src/MangakakalotGG/MangakakalotGG.ts
@@ -12,7 +12,7 @@ import {
 const SITE_DOMAIN = 'https://www.mangakakalot.gg'
 
 export const MangakakalotGGInfo: SourceInfo = {
-    version: getExportVersion('0.1.3'),
+    version: getExportVersion('0.1.4'),
     name: 'MangakakalotGG',
     icon: 'icon.png',
     author: 'Batmeow',
@@ -38,7 +38,7 @@ export class MangakakalotGG extends MangaBox {
     mangaListHomeSectionsPath = 'all'
 
     // Selector for manga in manga list.
-    mangaListSelector = 'div.truyen-list div.list-truyen-item-wrap'
+    mangaListSelector = 'div.comic-list div.list-comic-item-wrap'
 
     // Selector for subtitle in manga list.
     mangaSubtitleSelector = 'a.list-story-item-wrap-chapter'

--- a/src/Manganato/Manganato.ts
+++ b/src/Manganato/Manganato.ts
@@ -12,7 +12,7 @@ import {
 const SITE_DOMAIN = 'https://www.manganato.gg'
 
 export const ManganatoInfo: SourceInfo = {
-    version: getExportVersion('4.0.1'),
+    version: getExportVersion('4.0.2'),
     name: 'Manganato',
     icon: 'icon.png',
     author: 'Batmeow',
@@ -38,7 +38,7 @@ export class Manganato extends MangaBox {
     mangaListHomeSectionsPath = 'all'
 
     // Selector for manga in manga list.
-    mangaListSelector = 'div.truyen-list div.list-truyen-item-wrap'
+    mangaListSelector = 'div.comic-list div.list-comic-item-wrap'
 
     // Selector for subtitle in manga list.
     mangaSubtitleSelector = 'a.list-story-item-wrap-chapter'

--- a/src/Natomanga/Natomanga.ts
+++ b/src/Natomanga/Natomanga.ts
@@ -12,7 +12,7 @@ import {
 const SITE_DOMAIN = 'https://www.natomanga.com'
 
 export const NatomangaInfo: SourceInfo = {
-    version: getExportVersion('0.1.3'),
+    version: getExportVersion('0.1.4'),
     name: 'Natomanga',
     icon: 'icon.png',
     author: 'Batmeow',
@@ -38,7 +38,7 @@ export class Natomanga extends MangaBox {
     mangaListHomeSectionsPath = 'all'
 
     // Selector for manga in manga list.
-    mangaListSelector = 'div.truyen-list div.list-truyen-item-wrap'
+    mangaListSelector = 'div.comic-list div.list-comic-item-wrap'
 
     // Selector for subtitle in manga list.
     mangaSubtitleSelector = 'a.list-story-item-wrap-chapter'


### PR DESCRIPTION
This PR updates a few selectors to account for site changes.

Base Source:

- Update `mangaDescSelector` to include new description selector.

All Sub-Sources:

- Update `mangaListSelector `
- Increment patch version