### PR TITLE
MangaBox: Missed Manga ID Changes on Search Results.

### DIFF
--- a/src/MangaBox.ts
+++ b/src/MangaBox.ts
@@ -30,7 +30,7 @@ import {
     resetSettings
 } from './MangaBoxSettings'
 
-const BASE_VERSION = '2.0.0'
+const BASE_VERSION = '2.0.1'
 export const getExportVersion = (EXTENSION_VERSION: string): string => {
     return BASE_VERSION.split('.').map((x, index) => Number(x) + Number(EXTENSION_VERSION.split('.')[index])).join('.')
 }
@@ -427,7 +427,7 @@ export abstract class MangaBox implements SearchResultsProviding, MangaProviding
             const collecedIds: string[] = []
 
             for (const manga of $('div.panel_story_list div.story_item').toArray()) {
-                const mangaId = $('a', manga).first().attr('href')
+                const mangaId = this.parser.idCleaner($('a', manga).attr('href') ?? '')
                 const image = $('img', manga).first().attr('src') ?? ''
                 const title = decodeHTML($('h3.story_name a', manga).first().text().trim() ?? '')
                 const subtitle = decodeHTML($('h3.story_name + em.story_chapter a', manga).text().trim() ?? '')


### PR DESCRIPTION
Missed the `mangaId` swap on the search results function, normal search was working but Migration was not. Migration was failing to find a match due to the IDs not being correct. Did a test with these changes and migration search is working as intended.

Gave the BASE_VERSION a patch version bump to reflect the change on all sources.