### PR TITLE
Mangabox: General Improvements and Fixes

### DIFF
--- a/src/MangaBox.ts
+++ b/src/MangaBox.ts
@@ -262,7 +262,13 @@ export abstract class MangaBox implements SearchResultsProviding, MangaProviding
         this.checkResponseError(response)
 
         if (!response.data) throw new Error('No data received from Chapter API')
+
+        try {
         return JSON.parse(response.data)
+        }
+        catch (e) {
+            throw new Error(`Failed to parse chapter JSON for ${mangaId}!`)
+        }
     }
 
     async getChapters(mangaId: string): Promise<Chapter[]> {

--- a/src/MangaBox.ts
+++ b/src/MangaBox.ts
@@ -30,7 +30,7 @@ import {
     resetSettings
 } from './MangaBoxSettings'
 
-const BASE_VERSION = '2.0.1'
+const BASE_VERSION = '2.0.2'
 export const getExportVersion = (EXTENSION_VERSION: string): string => {
     return BASE_VERSION.split('.').map((x, index) => Number(x) + Number(EXTENSION_VERSION.split('.')[index])).join('.')
 }

--- a/src/MangaBox.ts
+++ b/src/MangaBox.ts
@@ -264,7 +264,7 @@ export abstract class MangaBox implements SearchResultsProviding, MangaProviding
         if (!response.data) throw new Error('No data received from Chapter API')
 
         try {
-        return JSON.parse(response.data)
+            return JSON.parse(response.data)
         }
         catch (e) {
             throw new Error(`Failed to parse chapter JSON for ${mangaId}!`)

--- a/src/MangaBox.ts
+++ b/src/MangaBox.ts
@@ -267,11 +267,13 @@ export abstract class MangaBox implements SearchResultsProviding, MangaProviding
 
     async getChapters(mangaId: string): Promise<Chapter[]> {
         const apiChapters: APIChapter[] = []
+
+        const limit = 5000
         let offset = 0
         let hasMore = true
 
         while (hasMore) {
-            const chapters_api_data = await this.getChaptersAPI(mangaId, 50, offset)
+            const chapters_api_data = await this.getChaptersAPI(mangaId, limit, offset)
             if (!chapters_api_data.success) throw new Error('API did not return success for chapters request')
             apiChapters.push(...chapters_api_data.data.chapters)
 
@@ -279,7 +281,7 @@ export abstract class MangaBox implements SearchResultsProviding, MangaProviding
                 hasMore = false
                 break
             }
-            offset += 50
+            offset += limit
         }
 
         return this.parser.parseChapters(apiChapters, mangaId, this)

--- a/src/Manganato/Manganato.ts
+++ b/src/Manganato/Manganato.ts
@@ -44,5 +44,5 @@ export class Manganato extends MangaBox {
     mangaSubtitleSelector = 'a.list-story-item-wrap-chapter'
 
     // CloudFlare Bypass url if required.
-    bypassPage = ''
+    bypassPage = `${this.baseURL}/search/story/`
 }

--- a/src/Natomanga/Natomanga.ts
+++ b/src/Natomanga/Natomanga.ts
@@ -44,5 +44,5 @@ export class Natomanga extends MangaBox {
     mangaSubtitleSelector = 'a.list-story-item-wrap-chapter'
 
     // CloudFlare Bypass url if required.
-    bypassPage = ''
+    bypassPage = `${this.baseURL}/search/story/`
 }


### PR DESCRIPTION
**Changes**

- Increase limit for amount of items returned by the Chapter API call to minimize the amount of called requests.
- Update the `bypassPage` URL on Manganato and Natomanga so that it now opens directly to the verification page.
- Add error handling around json parsing of chapter data and return more user friendly error on `SyntaxError`.
- Bump the patch version up 1 version across all sources using the `BASE_VERSION`.