### PR TITLE
Fix Madara

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@paperback/toolchain": "^0.8.7",
     "@paperback/types": "^0.8.7",
-    "cheerio": "^1.0.0",
+    "cheerio": "~1.1.0",
     "html-entities": "^2.5.2"
   }
 }

--- a/src/MangaLek/MangaLek.ts
+++ b/src/MangaLek/MangaLek.ts
@@ -15,7 +15,7 @@ import { MangaLekParser } from './MangaLekParser'
 const DOMAIN = 'https://lekmanga.net'
 
 export const MangaLekInfo: SourceInfo = {
-    version: getExportVersion('0.0.5'),
+    version: getExportVersion('0.0.7'),
     name: 'MangaLek',
     description: `Extension that pulls manga from ${DOMAIN}`,
     author: 'Netsky',


### PR DESCRIPTION
Warning, all other branches and extensions also need to be fixed the same way for every source that uses the `^1.0.0` semver for `cheerio`