### PR TITLE
Fix Methodnotimplemented errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "@paperback/types": "^0.8.7",
     "cheerio": "~1.1.0",
     "html-entities": "^2.5.2"
+  },
+  "overrides": {
+    "htmlparser2": "~10.0.0"
   }
 }

--- a/src/Madara.ts
+++ b/src/Madara.ts
@@ -25,7 +25,7 @@ import * as cheerio from 'cheerio'
 import { Parser } from './MadaraParser'
 import { URLBuilder } from './MadaraHelper'
 
-const BASE_VERSION = '3.2.1'
+const BASE_VERSION = '3.2.2'
 export const getExportVersion = (EXTENSION_VERSION: string): string => {
     return BASE_VERSION.split('.').map((x, index) => Number(x) + Number(EXTENSION_VERSION.split('.')[index])).join('.')
 }
@@ -44,15 +44,13 @@ export abstract class Madara implements SearchResultsProviding, MangaProviding, 
         interceptor: {
             interceptRequest: async (request: Request): Promise<Request> => {
 
-                request.headers = {
-                    ...(request.headers ?? {}),
-                    ...{
-                        'user-agent': await this.requestManager.getDefaultUserAgent(),
-                        'referer': `${this.baseUrl}/`,
-                        'origin': `${this.baseUrl}/`,
-                        ...(request.url.includes('wordpress.com') && { 'Accept': 'image/avif,image/webp,*/*' }) // Used for images hosted on Wordpress blogs
-                    }
-                }
+                request.headers = ({
+                    ...request.headers,
+                    'user-agent': await this.requestManager.getDefaultUserAgent(),
+                    'referer': `${this.baseUrl}/`,
+                    'origin': `${this.baseUrl}/`,
+                    ...request.url.includes('wordpress.com') && { 'Accept': 'image/avif,image/webp,*/*' }
+                })
                 request.cookies = [
                     App.createCookie({ name: 'wpmanga-adault', value: '1', domain: this.baseUrl }),
                     App.createCookie({ name: 'toonily-mature', value: '1', domain: this.baseUrl })

--- a/src/MadaraDex/MadaraDex.ts
+++ b/src/MadaraDex/MadaraDex.ts
@@ -47,15 +47,13 @@ export class MadaraDex extends Madara {
         interceptor: {
             interceptRequest: async (request: Request): Promise<Request> => {
 
-                request.headers = {
-                    ...(request.headers ?? {}),
-                    ...{
-                        'user-agent': 'Paperback-iOS',
-                        'referer': `${this.baseUrl}/`,
-                        'origin': `${this.baseUrl}/`,
-                        ...(request.url.includes('wordpress.com') && { 'Accept': 'image/avif,image/webp,*/*' }) // Used for images hosted on Wordpress blogs
-                    }
-                }
+                request.headers = ({
+                    ...request.headers,
+                    'user-agent': 'Paperback-iOS',
+                    'referer': `${this.baseUrl}/`,
+                    'origin': `${this.baseUrl}/`,
+                    ...request.url.includes('wordpress.com') && { 'Accept': 'image/avif,image/webp,*/*' }
+                })
                 request.cookies = [
                     App.createCookie({ name: 'wpmanga-adault', value: '1', domain: this.baseUrl }),
                     App.createCookie({ name: 'toonily-mature', value: '1', domain: this.baseUrl })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,7 @@
     "noImplicitOverride": true, /* Ensure overriding members in derived classes are marked with an 'override' modifier. */
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
     /* Module Resolution Options */
-    "moduleResolution": "node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "nodenext", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
Upgrades the project to use `nodenext` module resolution strategy in TypeScript configuration.

Increases the base version number for the extension export utility.

Refactors `interceptRequest` implementations in `Madara` and `MadaraDex` to use a cleaner object spread syntax for merging request headers, removing unnecessary nullish coalescing for existing headers.

Introduces an override for `htmlparser2` version in `package.json`, so Buffer is not used.